### PR TITLE
Version 0.8

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -52,8 +52,20 @@ https://github.com/adversary-org/foad
 Requirements
 ------------
 
--  Python 3.2 and above.
+-  Python 3.2 and above by default (see below).
 -  Only utilises standard modules (argparse, sys, random and a couple of
    others).
 -  Utilises the new standard for string formatting as of version 0.7.
 
+Optional Python 2.7 Support
+---------------------------
+
+- From Version 0.8 support for Python 2.7 has been restored.
+- Will not work with Python 2.6 or earlier.
+- Requires changing the first line to call python2 or python
+  (depending on the platform) instead of python3.
+- Operation ought to match the existing methods.
+- If there is ever some kind of conflict between Python 2 and Python
+  3, any changes made will favour Python 3.  If it is necessary to
+  disable this (by removing the "from __future__" import) then that
+  will be done.

--- a/foad.py
+++ b/foad.py
@@ -1,7 +1,14 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
+import sys
+
+if sys.version_info.major < 2:
+    sys.exit()
+elif sys.version_info.major == 2:
+    from __future__ import unicode_literals
+else:
+    pass
 
 ##
 # FOAD: Fucked Off Adversarial Degenerates (Fuck Off And Die)
@@ -12,7 +19,7 @@ from __future__ import unicode_literals
 #
 # https://github.com/adversary-org/foad
 #
-# Version:  0.7.8.0
+# Version:  0.7.8.1
 #
 # BTC:  1NpzDJg2pXjSqCL3XHTcyYaehiBN3kG3Lz
 # Licenses:  GNU Public License version 3 (GPLv3)
@@ -130,14 +137,13 @@ __license1__ = "GNU General Public License version 3 (GPLv3)"
 __license2__ = "Do What The Fuck You Want To, But It's Not My Fault Public License version 1 (WTFNMFPLv1)"
 __license3__ = "New BSD (3 clause) type"
 __license4__ = "Apache 2.0"
-__version__ = "0.7.8.0"
+__version__ = "0.7.8.1"
 __bitcoin__ = "1NpzDJg2pXjSqCL3XHTcyYaehiBN3kG3Lz"
 __openpgp__ = "0x321E4E2373590E5D"
 
 import argparse
 import locale
 import random
-import sys
 import textwrap
 
 if locale.getlocale()[1] == "UTF-8":

--- a/foad.py
+++ b/foad.py
@@ -1,14 +1,7 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-import sys
-
-if sys.version_info.major < 2:
-    sys.exit()
-elif sys.version_info.major == 2:
-    from __future__ import unicode_literals
-else:
-    pass
+from __future__ import unicode_literals
 
 ##
 # FOAD: Fucked Off Adversarial Degenerates (Fuck Off And Die)
@@ -19,7 +12,7 @@ else:
 #
 # https://github.com/adversary-org/foad
 #
-# Version:  0.7.8.1
+# Version:  0.7.8.2
 #
 # BTC:  1NpzDJg2pXjSqCL3XHTcyYaehiBN3kG3Lz
 # Licenses:  GNU Public License version 3 (GPLv3)
@@ -137,13 +130,14 @@ __license1__ = "GNU General Public License version 3 (GPLv3)"
 __license2__ = "Do What The Fuck You Want To, But It's Not My Fault Public License version 1 (WTFNMFPLv1)"
 __license3__ = "New BSD (3 clause) type"
 __license4__ = "Apache 2.0"
-__version__ = "0.7.8.1"
+__version__ = "0.7.8.2"
 __bitcoin__ = "1NpzDJg2pXjSqCL3XHTcyYaehiBN3kG3Lz"
 __openpgp__ = "0x321E4E2373590E5D"
 
 import argparse
 import locale
 import random
+import sys
 import textwrap
 
 if locale.getlocale()[1] == "UTF-8":

--- a/foad.py
+++ b/foad.py
@@ -12,7 +12,7 @@ from __future__ import unicode_literals
 #
 # https://github.com/adversary-org/foad
 #
-# Version:  0.7.8.2
+# Version:  0.8.0.0
 #
 # BTC:  1NpzDJg2pXjSqCL3XHTcyYaehiBN3kG3Lz
 # Licenses:  GNU Public License version 3 (GPLv3)
@@ -28,13 +28,23 @@ from __future__ import unicode_literals
 #
 # * Python 3.2 or later (developed with Python 3.4.x)
 # * Python modules: argparse, locale, random, sys, textwrap
+# * Python 2.7 supported from version 0.8 onward.
 #
 # Versions up to 0.4.x developed with Python 2.7.x.  Conversion to
-# Python 3 made from version 0.4.2.
+# Python 3 made from version 0.4.2.  Support for any Python 2 series
+# was removed from version 0.4.2 through to the end of the 0.7
+# releases.  Support was restored for Python 2.7 with version 0.8, but
+# only checked against 2.7.9 and requires manually editing the first
+# line on *nix systems to point to python or python2.  It cannot work
+# with Python 2.6 or earlier due to the use of argparse (and possibly
+# other things).
 #
 # Previous versions might have worked with Python 3.0 and 3.1 (I don't
 # know for sure, I never checked), but with the inclusion of the
 # argparse module this is now lo longer possible (if it ever was).
+#
+# If there is any future conflict between the Python 3 requirements
+# and Python 2, the development will *always* favour Python 3.
 #
 #
 # Options and notes:
@@ -130,7 +140,7 @@ __license1__ = "GNU General Public License version 3 (GPLv3)"
 __license2__ = "Do What The Fuck You Want To, But It's Not My Fault Public License version 1 (WTFNMFPLv1)"
 __license3__ = "New BSD (3 clause) type"
 __license4__ = "Apache 2.0"
-__version__ = "0.7.8.2"
+__version__ = "0.8.0.0"
 __bitcoin__ = "1NpzDJg2pXjSqCL3XHTcyYaehiBN3kG3Lz"
 __openpgp__ = "0x321E4E2373590E5D"
 

--- a/foad.py
+++ b/foad.py
@@ -1,4 +1,7 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
 
 ##
 # FOAD: Fucked Off Adversarial Degenerates (Fuck Off And Die)
@@ -9,7 +12,7 @@
 #
 # https://github.com/adversary-org/foad
 #
-# Version:  0.7.7.7
+# Version:  0.7.8.0
 #
 # BTC:  1NpzDJg2pXjSqCL3XHTcyYaehiBN3kG3Lz
 # Licenses:  GNU Public License version 3 (GPLv3)
@@ -127,7 +130,7 @@ __license1__ = "GNU General Public License version 3 (GPLv3)"
 __license2__ = "Do What The Fuck You Want To, But It's Not My Fault Public License version 1 (WTFNMFPLv1)"
 __license3__ = "New BSD (3 clause) type"
 __license4__ = "Apache 2.0"
-__version__ = "0.7.7.7"
+__version__ = "0.7.8.0"
 __bitcoin__ = "1NpzDJg2pXjSqCL3XHTcyYaehiBN3kG3Lz"
 __openpgp__ = "0x321E4E2373590E5D"
 


### PR DESCRIPTION

* Restored support for Python 2.7, but no prior version.
* Updated the docs slightly to reflect this.
* No guarantees given for Python 2.7 and still calls Python 3 by default.
* Requires manual editing to use with python 2.7.
