### PR TITLE
Tug-of-War

### DIFF
--- a/foad.py
+++ b/foad.py
@@ -14,7 +14,7 @@ from __future__ import division
 #
 # https://github.com/adversary-org/foad
 #
-# Version:  0.8.1.0
+# Version:  0.8.1.1
 #
 # BTC:  1NpzDJg2pXjSqCL3XHTcyYaehiBN3kG3Lz
 # Licenses:  GNU Public License version 3 (GPLv3)
@@ -139,7 +139,7 @@ __license1__ = "GNU General Public License version 3 (GPLv3)"
 __license2__ = "Do What The Fuck You Want To, But It's Not My Fault Public License version 1 (WTFNMFPLv1)"
 __license3__ = "New BSD (3 clause) type"
 __license4__ = "Apache 2.0"
-__version__ = "0.8.1.0"
+__version__ = "0.8.1.1"
 __bitcoin__ = "1NpzDJg2pXjSqCL3XHTcyYaehiBN3kG3Lz"
 __openpgp__ = "0x321E4E2373590E5D"
 
@@ -2040,6 +2040,27 @@ Alternatively run the help guide for foad.py (pydoc3 foad).
             msg = "{0}, you are as malignantly narcissistic, irrevocably misogynistic, thoroughly corrupt and utterly treasonous as Donald Trump!".format(target)
         else:
             msg = "You are as malignantly narcissistic, irrevocably misogynistic, thoroughly corrupt and utterly treasonous as Donald Trump!"
+        return msg
+
+    def tugwar(self):
+        if lt == 0 and lR == 0 and ls == 0 and le == 0:
+            msg = "This option requires name, relay and sender to be set, where name and relay are people/entities, while sender is who or what is caught between them.  Extra may be used to specify certain variations."
+        elif lt == 0 and lR > 0 and ls > 0 and le == 0:
+            msg = "For fuck's sake! Will you and {0} stop using {1} as the rope in their game of tug-of-war?!".format(relay, sender)
+        elif lt > 0 and lR > 0 and ls > 0 and le == 0:
+            msg = "For fuck's sake! Will {0} and {1} stop using {2} as the rope in their fucking game of tug-of-war?!".format(target, relay, sender)
+        elif lt > 0 and lR > 0 and ls > 0 and le > 0 and extra == "when":
+            msg = "For fuck's sake! When will {0} and {1} stop using {2} as the rope in their fucking game of tug-of-war?!".format(target, relay, sender)
+        elif lt > 0 and lR > 0 and ls > 0 and le > 0 and extra == "need":
+            msg = "For fuck's sake! Fucking {0} and {1} need to stop using {2} as the rope in their fucking game of tug-of-war right fucking now!".format(target, relay, sender)
+        elif lt > 0 and lR > 0 and ls > 0 and le > 0 and extra == "needthe":
+            msg = "For fuck's sake! The fucking {0} and {1} need to stop using {2} as the rope in their fucking game of tug-of-war right fucking now!".format(target, relay, sender)
+        elif lt > 0 and lR > 0 and ls > 0 and le > 0 and extra == "needthat":
+            msg = "For fuck's sake! That fucking {0} and {1} need to stop using {2} as the rope in their fucking game of tug-of-war right fucking now!".format(target, relay, sender)
+        elif lt > 0 and lR > 0 and ls > 0 and le > 0 and extra == "needthose":
+            msg = "For fuck's sake! Those fucking {0} and {1} need to stop using {2} as the rope in their fucking game of tug-of-war right fucking now!".format(target, relay, sender)
+        else:
+            msg = "Optional extras: when, need, needthe, needthat, needthose."
         return msg
 
     # All the twog quotes are from TheTweetOfGod.


### PR DESCRIPTION
* Added tug-of-war option.
* Requires multiple flags, including name, relay, sender and
  (optionally) extra.
* There is a variant permitting name to be dropped, but not relay or
  sender.
* Not using any flags will prompt a hint.
* Only including the extra flag will list all the extra possibilities.